### PR TITLE
theme.txt: Add space between OS icon and text

### DIFF
--- a/EndeavourOS/theme.txt
+++ b/EndeavourOS/theme.txt
@@ -22,6 +22,7 @@ terminal-border: "0"
   item_font = "Unifont Regular 16"
   item_color = "#cccccc"
   selected_item_color = "#ffffff"
+  item_icon_space = 15
   item_height = 24
   item_spacing = 16
   selected_item_pixmap_style = "select_*.png"


### PR DESCRIPTION
### What was changed?
This is adds the line `item_icon_space = 15` to the boot menu section of `theme.txt` in order to increase the space between the OS icon shown in the Grub menu and the text description next to it.

### How does it look like?
This is the **current** style:
![image](https://user-images.githubusercontent.com/2453666/167702840-51397553-a751-4504-b1f3-4a559a1ed421.png)


This is the **new** style with the **change** applied:
![image](https://user-images.githubusercontent.com/2453666/167702927-388e08a6-3fc6-439f-b72b-8869811ff556.png)


Note the increased space between the icons and the text "EndeavourOS".

### Why?
Better visual appeal of the Grub menu.